### PR TITLE
Add a node_binary rule.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -6,6 +6,11 @@ load(
   "docker_push",
 )
 
+load(
+  "//:node.bzl",
+  "node_binary"
+)
+
 docker_build(
    name = "hello",
    base = "@blah//:image.tar",
@@ -23,4 +28,11 @@ docker_push(
   image = ":hello",
   registry = "gcr.io",
   repository = "convoy-adapter/nodejs/hello-express"
+)
+
+node_binary(
+  name = "hello_node",
+  srcs = [":hello_express.js"],
+  entrypoint=":hello_express.js",
+  node_modules = "@blah//:node_modules"
 )


### PR DESCRIPTION
Kind of hacky, but it works:

```shell
$ bazel run :hello_node
INFO: Found 1 target...
Target //:hello_node up-to-date:
  bazel-bin/hello_node
INFO: Elapsed time: 2.314s, Critical Path: 0.00s

INFO: Running command line: bazel-bin/hello_node
+ export NODE_PATH=./external/blah/node_modules
+ NODE_PATH=./external/blah/node_modules
+ node hello_express.js
Example app listening on port 3000!
```